### PR TITLE
Iterative ROI Screenshots

### DIFF
--- a/napari/_qt/qt_main_window.py
+++ b/napari/_qt/qt_main_window.py
@@ -10,6 +10,7 @@ import sys
 import time
 import warnings
 from collections.abc import MutableMapping, Sequence
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -81,6 +82,7 @@ from napari.settings import get_settings
 from napari.utils import perf
 from napari.utils._proxies import PublicOnlyProxy
 from napari.utils.events import Event
+from napari.utils.geometry import get_center_bbox
 from napari.utils.io import imsave
 from napari.utils.misc import (
     in_ipython,
@@ -92,13 +94,13 @@ from napari.utils.notifications import Notification
 from napari.utils.theme import _themes, get_system_theme
 from napari.utils.translations import trans
 
-_sentinel = object()
-
 if TYPE_CHECKING:
     from magicgui.widgets import Widget
     from qtpy.QtGui import QImage
 
     from napari.viewer import Viewer
+
+_sentinel = object()
 
 
 MenuStr = Literal[
@@ -1729,6 +1731,93 @@ class Window:
             imsave(path, img)
         return img
 
+    def export_rois(
+        self,
+        rois: list[np.ndarray],
+        paths: Optional[Union[str, Path, list[Union[str, Path]]]] = None,
+        scale: Optional[float] = None,
+    ):
+        """Export the given rectangular rois to specified file paths.
+
+        For each shape, moves the camera to the center of the shape
+        and adjust the canvas size to fit the shape.
+        Note: The shape height and width can be of type float.
+        However, the canvas size only accepts a tuple of integers.
+        This can result in slight misalignment.
+
+        Parameters
+        ----------
+        rois: list[np.ndarray]
+            A list of arrays  with each being of shape (4, 2) representing
+            a rectangular roi.
+        paths: str, Path, list[str, Path], optional
+            Where to save the rois. If a string or a Path, a directory will
+            be created if it does not exist yet and screenshots will be
+            saved with filename `roi_{n}.png` where n is the nth roi. If
+            paths is a list of either string or paths, these need to be the
+            full paths of where to store each individual roi. In this case
+            the length of the list and the number of rois must match.
+            If None, the screenshots will only be returned and not saved
+            to disk.
+        scale: float, optional
+            Scale factor used to increase resolution of canvas for the screenshot.
+            By default, uses the displayed scale.
+
+        Returns
+        -------
+        screenshot_list: list
+            The list with roi screenshots.
+
+        """
+        if (
+            paths is not None
+            and isinstance(paths, list)
+            and len(paths) != len(rois)
+        ):
+            raise ValueError(
+                trans._(
+                    'The number of file paths does not match the number of ROI shapes',
+                    deferred=True,
+                )
+            )
+
+        if isinstance(paths, (str, Path)):
+            storage_dir = Path(paths).expanduser()
+            storage_dir.mkdir(parents=True, exist_ok=True)
+            paths = [storage_dir / f'roi_{n}.png' for n in range(len(rois))]
+
+        if self._qt_viewer.viewer.dims.ndisplay > 2:
+            raise NotImplementedError(
+                "'export_rois' is not implemented for 3D view."
+            )
+
+        screenshot_list = []
+        camera = self._qt_viewer.viewer.camera
+        start_camera_center = camera.center
+        start_camera_zoom = camera.zoom
+        canvas = self._qt_viewer.canvas
+        prev_size = canvas.size
+
+        visible_dims = list(self._qt_viewer.viewer.dims.displayed)
+        step = min(self._qt_viewer.viewer.layers.extent.step[visible_dims])
+
+        for index, roi in enumerate(rois):
+            center_coord, height, width = get_center_bbox(roi)
+            camera.center = center_coord
+            canvas.size = (int(height / step), int(width / step))
+
+            camera.zoom = 1 / step
+            path = paths[index] if paths is not None else None
+            screenshot_list.append(
+                self.screenshot(path=path, canvas_only=True, scale=scale)
+            )
+
+        canvas.size = prev_size
+        camera.center = start_camera_center
+        camera.zoom = start_camera_zoom
+
+        return screenshot_list
+
     def screenshot(
         self, path=None, size=None, scale=None, flash=True, canvas_only=False
     ):
@@ -1736,7 +1825,7 @@ class Window:
 
         Parameters
         ----------
-        path : str
+        path : str, Path
             Filename for saving screenshot image.
         size : tuple (int, int)
             Size (resolution) of the screenshot. By default, the currently displayed size.

--- a/napari/utils/geometry.py
+++ b/napari/utils/geometry.py
@@ -837,3 +837,28 @@ def find_nearest_triangle_intersection(
     intersection = intersection_points[closest_triangle_index]
 
     return closest_intersected_triangle_index, intersection
+
+
+def get_center_bbox(roi: np.ndarray) -> tuple[list[float], int, int]:
+    """Get the center coordinate, height, width of the roi.
+
+    Parameters
+    ----------
+    roi : np.ndarray
+        An array of shape (4, 2) representing a rectangular roi.
+
+    Returns
+    -------
+    center_coords: list[float, float]
+        center y and x coordinates of the roi
+    height: int
+        height of the roi in data pixels
+    width: int
+        width of the roi in data pixels
+
+    """
+    height, width = roi.max(axis=0) - roi.min(axis=0)
+    min_y, min_x = roi.min(axis=0)
+    center_coords = [min_y + height / 2, min_x + width / 2]
+
+    return center_coords, height, width

--- a/napari/viewer.py
+++ b/napari/viewer.py
@@ -1,5 +1,6 @@
 import typing
-from typing import TYPE_CHECKING, Optional
+from pathlib import Path
+from typing import Optional, Union
 from weakref import WeakSet
 
 import magicgui as mgui
@@ -9,7 +10,7 @@ from napari.components.viewer_model import ViewerModel
 from napari.utils import _magicgui
 from napari.utils.events.event_utils import disconnect_events
 
-if TYPE_CHECKING:
+if typing.TYPE_CHECKING:
     # helpful for IDE support
     from napari._qt.qt_main_window import Window
 
@@ -142,6 +143,54 @@ class Viewer(ViewerModel):
             scale=scale_factor,
             flash=flash,
         )
+
+    def export_rois(
+        self,
+        rois: list[np.ndarray],
+        paths: Optional[Union[str, Path, list[Union[str, Path]]]] = None,
+        scale: Optional[float] = None,
+    ):
+        """Export the given rectangular rois to specified file paths.
+
+        Iteratively take a screenshot of each given roi. Note that 3D rois
+        or taking rois when number of dimensions displayed in the viewer
+        canvas is 3, is currently not supported.
+
+        Parameters
+        ----------
+        rois: numpy array
+            A list of arrays with each having shape (4, 2) representing a
+            rectangular roi.
+        paths: str, Path, list[str, Path], optional
+            Where to save the rois. If a string or a Path, a directory will
+            be created if it does not exist yet and screenshots will be saved
+            with filename `roi_{n}.png` where n is the nth roi. If paths is
+            a list of either string or paths, these need to be the full paths
+            of where to store each individual roi. In this case
+            the length of the list and the number of rois must match.
+            If None, the screenshots will only be returned
+            and not saved to disk.
+        scale: float, optional
+            Scale factor used to increase resolution of canvas for the screenshot.
+            By default, uses the displayed scale.
+
+        Returns
+        -------
+        screenshot_list: list
+            The list containing all the screenshots.
+        """
+        # Check to see if roi has shape (n,2,2)
+        if any(roi.shape[-2:] != (4, 2) for roi in rois):
+            raise ValueError(
+                'ROI found with invalid shape, all rois must have shape (4, 2), i.e. have 4 corners defined in 2 '
+                'dimensions. 3D is not supported.'
+            )
+
+        screenshot_list = self.window.export_rois(
+            rois, paths=paths, scale=scale
+        )
+
+        return screenshot_list
 
     def screenshot(
         self,


### PR DESCRIPTION
Recreated from original PR: https://github.com/napari/napari/pull/7209

Motivation

When drawing rois using shapes layer and taking screenshots, the user is required to manually center a particular roi and adjust the zoom level to allow for this. After having drawn multiple ROIs, perhaps even across multiple samples a user might quickly want to generate all the screenshots. This PR allows for that.

:rocket: Feature
Similar to the way the export_figure function works, this function iteratively centers the camera to the center of each ROI and adjusts the size of...